### PR TITLE
fixed getDBFieldnames to not insert mainkeys that was already used

### DIFF
--- a/core.go
+++ b/core.go
@@ -73,8 +73,10 @@ func (dao *TableGateway) getDBFieldnames(data interface{}) string {
 		for k := range fields {
 			if strings.Contains(k, ".") {
 				parts := strings.Split(k, ".")
-				mainkeys[parts[0]] = 1
-			} else {
+        if parts[0] != dao.KeyFieldName {
+          mainkeys[parts[0]] = 1
+        }
+      } else {
 				keys[i] = k
 				i++
 			}


### PR DESCRIPTION
mainkeys will be inserted twice into statements when using Postgres-Driver